### PR TITLE
refactor: change token and account coupling system

### DIFF
--- a/src/Config/seat-connector.config.php
+++ b/src/Config/seat-connector.config.php
@@ -43,5 +43,10 @@ return [
             'label' => 'seat-connector-teamspeak::seat.api_key',
             'type'  => 'text',
         ],
+        [
+            'name'  => 'registration_group_name',
+            'label' => 'seat-connector-teamspeak::seat.registration_group',
+            'type'  => 'text',
+        ],
     ],
 ];

--- a/src/Exceptions/EmptyResultException.php
+++ b/src/Exceptions/EmptyResultException.php
@@ -1,8 +1,8 @@
 <?php
-/**
+/*
  * This file is part of SeAT Teamspeak Connector.
  *
- * Copyright (C) 2019  Warlof Tutsimo <loic.leuilliot@gmail.com>
+ * Copyright (C) 2020  Warlof Tutsimo <loic.leuilliot@gmail.com>
  *
  * SeAT Teamspeak Connector  is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,10 +18,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-return [
-    'server_host'        => 'Server Address',
-    'server_port'        => 'Server Port',
-    'api_base_uri'       => 'Api Base Uri',
-    'api_key'            => 'Api Key',
-    'registration_group' => 'Registration Server Group',
-];
+namespace Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions;
+
+/**
+ * Class EmptyResultException.
+ *
+ * @package Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions
+ */
+class EmptyResultException extends TeamspeakException
+{
+
+}

--- a/src/Exceptions/InvalidServerGroupException.php
+++ b/src/Exceptions/InvalidServerGroupException.php
@@ -1,8 +1,8 @@
 <?php
-/**
+/*
  * This file is part of SeAT Teamspeak Connector.
  *
- * Copyright (C) 2019  Warlof Tutsimo <loic.leuilliot@gmail.com>
+ * Copyright (C) 2020  Warlof Tutsimo <loic.leuilliot@gmail.com>
  *
  * SeAT Teamspeak Connector  is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,10 +18,24 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-return [
-    'server_host'        => 'Server Address',
-    'server_port'        => 'Server Port',
-    'api_base_uri'       => 'Api Base Uri',
-    'api_key'            => 'Api Key',
-    'registration_group' => 'Registration Server Group',
-];
+namespace Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions;
+
+use Throwable;
+
+/**
+ * Class InvalidServerGroupException.
+ *
+ * @package Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions
+ */
+class InvalidServerGroupException extends TeamspeakException
+{
+    /**
+     * InvalidServerGroupException constructor.
+     *
+     * @param string $server_group
+     */
+    public function __construct(string $server_group)
+    {
+        parent::__construct(sprintf('Server Group %s is not found.', $server_group));
+    }
+}

--- a/src/Http/Controllers/RegistrationController.php
+++ b/src/Http/Controllers/RegistrationController.php
@@ -20,9 +20,8 @@
 
 namespace Warlof\Seat\Connector\Drivers\Teamspeak\Http\Controllers;
 
-use Illuminate\Support\Str;
+use Illuminate\Support\Arr;
 use Seat\Web\Http\Controllers\Controller;
-use Warlof\Seat\Connector\Drivers\IClient;
 use Warlof\Seat\Connector\Drivers\IUser;
 use Warlof\Seat\Connector\Drivers\Teamspeak\Driver\TeamspeakClient;
 use Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions\TeamspeakException;
@@ -39,6 +38,21 @@ use Warlof\Seat\Connector\Models\User;
  */
 class RegistrationController extends Controller
 {
+    /**
+     * @var \Warlof\Seat\Connector\Drivers\Teamspeak\Driver\TeamspeakClient
+     */
+    private $client;
+
+    /**
+     * RegistrationController constructor.
+     *
+     * @throws \Warlof\Seat\Connector\Exceptions\DriverException
+     */
+    public function __construct()
+    {
+        $this->client = TeamspeakClient::getInstance();
+    }
+
     /**
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\Http\RedirectResponse|\Illuminate\View\View
      * @throws \Seat\Services\Exceptions\SettingException
@@ -57,14 +71,25 @@ class RegistrationController extends Controller
             if (! property_exists($settings, 'server_port') || is_null($settings->server_port))
                 throw new DriverSettingsException('Parameter server_port is missing.');
 
-            $registration_nickname = Str::random(30);
+            if (! property_exists($settings, 'registration_group_id') || is_null($settings->registration_group_id))
+                throw new DriverSettingsException('Parameter registration_group is missing.');
 
-            session(['seat-connector.teamspeak.registration_uuid' => $registration_nickname]);
+            $this->uncoupleUser();
+
+            $registration_token = $this->client->tokenAdd(auth()->user(), $settings->registration_group_id);
+
+            session(['seat-connector.teamspeak.registration_token' => $registration_token]);
         } catch (DriverSettingsException $e) {
             event(new EventLogger('teamspeak', 'critical', 'registration', $e->getMessage()));
             logger()->error(sprintf('[seat-connector][teamspeak] %d : %s', $e->getCode(), $e->getMessage()));
 
             return redirect()->back()
+                ->with('error', $e->getMessage());
+        } catch (DriverException | TeamspeakException $e) {
+            logger()->error(sprintf('[seat-connector][teamspeak] %d : %s', $e->getCode(), $e->getMessage()));
+            event(new EventLogger('teamspeak', 'critical', 'registration', $e->getMessage()));
+
+            return redirect()->route('seat-connector.identities')
                 ->with('error', $e->getMessage());
         }
 
@@ -72,7 +97,7 @@ class RegistrationController extends Controller
         $identities = User::where('user_id', auth()->user()->id)->get();
 
         return view('seat-connector-teamspeak::registrations.confirm',
-            compact('drivers', 'identities', 'settings', 'registration_nickname'));
+            compact('drivers', 'identities', 'settings', 'registration_token'));
     }
 
     /**
@@ -82,20 +107,17 @@ class RegistrationController extends Controller
     public function handleProviderCallback()
     {
         // determine the expected nickname for that user
-        $searched_nickname = session('seat-connector.teamspeak.registration_uuid');
+        $searched_token = session('seat-connector.teamspeak.registration_token');
 
         try {
-            // retrieve the teamspeak client instance
-            $client = TeamspeakClient::getInstance();
-
             // search for the expected user
-            $match_user = $client->findUserByName($searched_nickname);
+            $match_user = Arr::first($this->client->customSearch(auth()->user()));
         } catch (InvalidDriverIdentityException $e) {
             logger()->error(sprintf('[seat-connector][teamspeak] %d : %s', $e->getCode(), $e->getMessage()));
             event(new EventLogger('teamspeak', 'critical', 'registration', $e->getMessage()));
 
             return redirect()->route('seat-connector.identities')
-                ->with('error', sprintf('Sorry, but we were not able to find you with nickname %s on the server.', $searched_nickname));
+                ->with('error', sprintf('Sorry, but we were not able to find you with nickname %s on the server.', $searched_token));
         } catch (DriverException | TeamspeakException $e) {
             logger()->error(sprintf('[seat-connector][teamspeak] %d : %s', $e->getCode(), $e->getMessage()));
             event(new EventLogger('teamspeak', 'critical', 'registration', $e->getMessage()));
@@ -104,20 +126,14 @@ class RegistrationController extends Controller
                 ->with('error', $e->getMessage());
         }
 
-        $original_user = User::where('connector_type', 'teamspeak')->where('user_id', auth()->user()->id)->first();
-
-        // if connector ID is a new one - revoke existing access from the old ID
-        if (! is_null($original_user) && $original_user->connector_id != $match_user->getClientId())
-            $this->revokeOldIdentity($client, $original_user);
-
         // register the user
-        $profile = $this->coupleUser(auth()->user()->id, $searched_nickname, $match_user);
+        $profile = $this->coupleUser(auth()->user()->id, $match_user);
 
         $allowed_sets = $profile->allowedSets();
 
         foreach ($allowed_sets as $set_id) {
             try {
-                $set = $client->getSet($set_id);
+                $set = $this->client->getSet($set_id);
 
                 if (is_null($set)) {
                     logger()->error(sprintf('[seat-connector][teamspeak] Unable to retrieve Server Group with ID %s', $set_id));
@@ -147,48 +163,64 @@ class RegistrationController extends Controller
      * @param \Warlof\Seat\Connector\Drivers\IUser $user
      * @return \Warlof\Seat\Connector\Models\User
      */
-    private function coupleUser(int $user_id, string $nickname, IUser $user): User
+    private function coupleUser(int $user_id, IUser $user): User
     {
         $profile = User::updateOrCreate([
             'user_id'        => $user_id,
             'connector_type' => 'teamspeak',
         ], [
-            'connector_name' => $nickname,
+            'connector_name' => $user->getName(),
             'connector_id'   => $user->getClientId(),
             'unique_id'      => $user->getUniqueId(),
         ]);
 
         event(new EventLogger('teamspeak', 'notice', 'registration',
             sprintf('User %s (%d) has been registered with ID %s and UID %s',
-                $nickname, $user_id, $user->getClientId(), $user->getUniqueId())));
+                $user->getName(), $user_id, $user->getClientId(), $user->getUniqueId())));
 
         return $profile;
     }
 
     /**
-     * @param \Warlof\Seat\Connector\Drivers\IClient $client
-     * @param \Warlof\Seat\Connector\Models\User $old_identity
+     * Manage user uncoupling.
+     *
+     * @throws \Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions\CommandException
+     * @throws \Warlof\Seat\Connector\Drivers\Teamspeak\Exceptions\LoginException
+     * @throws \Warlof\Seat\Connector\Exceptions\DriverException
+     * @throws \Warlof\Seat\Connector\Exceptions\InvalidDriverIdentityException
      */
-    private function revokeOldIdentity(IClient $client, User $old_identity)
+    private function uncoupleUser()
     {
-        try {
-            // retrieve teamspeak user related to old identity
-            $user = $client->getUser($old_identity->connector_id);
+        // retrieve existing binding
+        $binding = User::where('connector_type', 'teamspeak')->where('user_id', auth()->user()->id)->first();
 
-            // pull its active sets
-            $sets = $user->getSets();
+        // attempt to retrieve any existing speaker linked to this account
+        // kick them and remove them from the database
+        if ($binding) {
 
-            // revoke all of them
-            foreach ($sets as $set) {
-                $user->removeSet($set);
+            // collect all connected clients related to this UID
+            $clients = $this->client->clientGetIds($binding->unique_id);
+
+            // kick clients from the server
+            if (count($clients) > 0) {
+                $this->client->kickClientFromServerInstance($clients);
+
+                $speaker = $this->client->getUser($binding->connector_id);
+                $this->client->deleteClientFromServerInstance($speaker);
             }
-        } catch (InvalidDriverIdentityException $e) {
-            return;
+
+            $binding->delete();
         }
 
-        // log action
-        event(new EventLogger('discord', 'warning', 'registration',
-            sprintf('User %s (%d) has been uncoupled from ID %s and UID %s',
-                $old_identity->connector_name, $old_identity->user_id, $old_identity->connector_id, $old_identity->unique_id)));
+        $speakers = $this->client->customSearch(auth()->user());
+
+        foreach ($speakers as $speaker) {
+            $clients = $this->client->clientGetIds($speaker->getUniqueId());
+
+            if (count($clients))
+                $this->client->kickClientFromServerInstance($clients);
+
+            $this->client->deleteClientFromServerInstance($speaker);
+        }
     }
 }

--- a/src/Http/Validation/Settings.php
+++ b/src/Http/Validation/Settings.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * This file is part of SeAT Teamspeak Connector.
+ *
+ * Copyright (C) 2020  Warlof Tutsimo <loic.leuilliot@gmail.com>
+ *
+ * SeAT Teamspeak Connector  is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * SeAT Teamspeak Connector is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Warlof\Seat\Connector\Drivers\Teamspeak\Http\Validation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Class Settings.
+ *
+ * @package Warlof\Seat\Connector\Drivers\Teamspeak\Http\Validation
+ */
+class Settings extends FormRequest
+{
+    /**
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function rules()
+    {
+        return [
+            'server_host'             => 'required|string',
+            'server_port'             => 'required|numeric|min:1|max:65535',
+            'api_base_uri'            => 'required|url',
+            'api_key'                 => 'required|string',
+            'registration_group_name' => 'required|string',
+        ];
+    }
+}

--- a/src/resources/views/registrations/includes/modal.blade.php
+++ b/src/resources/views/registrations/includes/modal.blade.php
@@ -29,16 +29,16 @@
           </div>
           @endif
           <div class="form-group">
-            <label class="col-sm-3 control-label" for="ts-nickname">Nickname</label>
+            <label class="col-sm-3 control-label" for="ts-nickname">Privilege Key</label>
             <div class="col-sm-9">
-              <input type="text" value="{{ $registration_nickname }}" readonly="readonly" id="ts-nickname" class="form-control input-sm" />
+              <input type="text" value="{{ $registration_token }}" readonly="readonly" id="ts-nickname" class="form-control input-sm" />
             </div>
           </div>
         </form>
       </div>
       <div class="modal-footer">
         <button class="btn btn-outline-secondary pull-left" type="button" data-dismiss="modal">Close</button>
-        <a href="{{ sprintf('ts3server://%s:%d?nickname=%s', $settings->server_host, $settings->server_port, $registration_nickname) }}" class="btn btn-primary">
+        <a href="{{ sprintf('ts3server://%s:%d?nickname=%s&token=%s', $settings->server_host, $settings->server_port, auth()->user()->name, $registration_token) }}" class="btn btn-primary">
           <i class="fas fa-sign-in-alt"></i> Join
         </a>
         <button class="btn btn-success" type="submit" form="ts-registration-form">


### PR DESCRIPTION
This is a new approach at user enrollment flow.

Instead asking SeAT to generate a random token, we ask Teamspeak to provide us one that we will use to bind the SeAT account to a Teamspeak account. This capability is provided by Teamspeak user custom information - as per this [valuate post](https://forum.teamspeak.com/threads/56435-How-to-integrate-large-existing-user-bases-into-TeamSpeak-3).

User will join Teamspeak server using his main character name and consume the provided token.
In case the user don't have teampseak client mapped to `ts3server://` protocol, we still show him the privilege token, so he will be able to manually set his account.

Before user being redirected to the authentication modal, we kick and remove all mapped account. Prior, this step was done after redirection.

**BREAKING CHANGES**
This feature is requesting to define a server group which will be used during enrollment flow. This Server Group will be used by the token, and removed as soon as policy are applied (except if you also grant that server group on your policy)